### PR TITLE
Fix types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,32 +1,32 @@
 {
   "name": "@20minutes/draft-convert",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Extensibly serialize & deserialize Draft.js ContentState",
-  "main": "lib/index.js",
-  "types": "types/index.d.ts",
-  "module": "esm/index.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./types/index.d.ts",
-      "require": "./lib/index.js",
-      "import": "./esm/index.js"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.mjs"
     }
   },
   "repository": "20minutes/draft-convert",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:esm",
-    "build:cjs": "swc src -d lib --config-file .swcrc.cjs --strip-leading-paths --delete-dir-on-start",
-    "build:esm": "swc src -d esm --config-file .swcrc.esm --strip-leading-paths --delete-dir-on-start",
+    "build": "yarn clean && yarn build:esm && yarn build:cjs && yarn build:types",
+    "build:cjs": "swc src -d dist --config-file .swcrc.cjs --strip-leading-paths && node scripts/rename-dist-cjs-entry.js",
+    "build:esm": "swc src -d dist --config-file .swcrc.esm --strip-leading-paths --delete-dir-on-start --out-file-extension mjs && node scripts/fix-dist-esm-imports.js",
+    "build:types": "node scripts/build-dist-types.js",
     "test": "jest",
     "test:watch": "jest --watch",
-    "clean": "rimraf ./lib ./esm",
+    "clean": "rimraf ./dist ./lib ./esm",
     "build-and-test": "yarn clean && yarn test",
     "lint": "eslint src/ test/"
   },
   "files": [
-    "types",
-    "lib",
-    "esm"
+    "dist"
   ],
   "keywords": [
     "draft",

--- a/scripts/build-dist-types.js
+++ b/scripts/build-dist-types.js
@@ -1,0 +1,18 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const rootDirectory = process.cwd()
+const sourceTypesEntry = path.join(rootDirectory, 'types', 'index.d.ts')
+const distDirectory = path.join(rootDirectory, 'dist')
+const destTypesEntry = path.join(distDirectory, 'index.d.ts')
+
+if (!fs.existsSync(sourceTypesEntry)) {
+  throw new Error(`Missing types entry: ${sourceTypesEntry}`)
+}
+
+if (!fs.existsSync(distDirectory)) {
+  throw new Error(`Missing dist directory: ${distDirectory}`)
+}
+
+const declarationSource = fs.readFileSync(sourceTypesEntry, 'utf8')
+fs.writeFileSync(destTypesEntry, declarationSource, 'utf8')

--- a/scripts/fix-dist-esm-imports.js
+++ b/scripts/fix-dist-esm-imports.js
@@ -1,0 +1,56 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const distDirectory = path.join(process.cwd(), 'dist')
+
+const toMjsSpecifier = (specifier) => {
+  if (!specifier.startsWith('./') && !specifier.startsWith('../')) {
+    return specifier
+  }
+
+  const [pathname, suffix = ''] = specifier.split(/([?#].*)/, 2)
+  if (!pathname.endsWith('.js')) {
+    return specifier
+  }
+
+  return `${pathname.slice(0, -3)}.mjs${suffix}`
+}
+
+const rewriteSpecifiers = (source) =>
+  source
+    .replace(
+      /(\bfrom\s+['"])(\.\.?\/[^'"]+)(['"])/g,
+      (full, before, specifier, after) =>
+        `${before}${toMjsSpecifier(specifier)}${after}`
+    )
+    .replace(
+      /(\bimport\s*['"])(\.\.?\/[^'"]+)(['"])/g,
+      (full, before, specifier, after) =>
+        `${before}${toMjsSpecifier(specifier)}${after}`
+    )
+    .replace(
+      /(\bimport\s*\(\s*['"])(\.\.?\/[^'"]+)(['"]\s*\))/g,
+      (full, before, specifier, after) =>
+        `${before}${toMjsSpecifier(specifier)}${after}`
+    )
+
+const walkFiles = (directory) =>
+  fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name)
+    if (entry.isDirectory()) {
+      return walkFiles(entryPath)
+    }
+    return entryPath.endsWith('.mjs') ? [entryPath] : []
+  })
+
+if (!fs.existsSync(distDirectory)) {
+  throw new Error(`Missing dist directory: ${distDirectory}`)
+}
+
+for (const filePath of walkFiles(distDirectory)) {
+  const source = fs.readFileSync(filePath, 'utf8')
+  const rewritten = rewriteSpecifiers(source)
+  if (rewritten !== source) {
+    fs.writeFileSync(filePath, rewritten, 'utf8')
+  }
+}

--- a/scripts/rename-dist-cjs-entry.js
+++ b/scripts/rename-dist-cjs-entry.js
@@ -1,0 +1,16 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const distDirectory = path.join(process.cwd(), 'dist')
+const cjsJsEntry = path.join(distDirectory, 'index.js')
+const cjsEntry = path.join(distDirectory, 'index.cjs')
+
+if (!fs.existsSync(cjsJsEntry)) {
+  throw new Error(`Missing CJS entry to rename: ${cjsJsEntry}`)
+}
+
+if (fs.existsSync(cjsEntry)) {
+  fs.rmSync(cjsEntry)
+}
+
+fs.renameSync(cjsJsEntry, cjsEntry)

--- a/src/convertFromHTML.js
+++ b/src/convertFromHTML.js
@@ -10,11 +10,14 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-import * as Immutable from 'immutable'
-import * as DraftJS from 'draft-js'
+// immutable is CJS-only; default import maps to module.exports for Node ESM interop.
+// eslint-disable-next-line import/default
+import Immutable from 'immutable'
+import DraftJS from 'draft-js'
 import getSafeBodyFromHTML from './util/parseHTML.js'
 import rangeSort from './util/rangeSort.js'
 
+// eslint-disable-next-line import/no-named-as-default-member
 const { List, Map, OrderedSet } = Immutable
 const {
   BlockMapBuilder,

--- a/src/convertToHTML.js
+++ b/src/convertToHTML.js
@@ -1,7 +1,7 @@
 import invariant from 'invariant'
 import React from 'react'
 import ReactDOMServer from 'react-dom/server'
-import * as DraftJS from 'draft-js'
+import DraftJS from 'draft-js'
 import encodeBlock from './encodeBlock.js'
 import blockEntities from './blockEntities.js'
 import blockInlineStyles from './blockInlineStyles.js'

--- a/test/spec/build-output-test.js
+++ b/test/spec/build-output-test.js
@@ -1,12 +1,22 @@
 const { execFileSync } = require('node:child_process')
 const fs = require('node:fs')
+const os = require('node:os')
 const path = require('node:path')
 const { pathToFileURL } = require('node:url')
 
-const runCommand = (command, args) => {
+const npmCacheDirectory = path.join(os.tmpdir(), 'draft-convert-npm-cache')
+fs.mkdirSync(npmCacheDirectory, { recursive: true })
+
+const runCommand = (command, args, options = {}) => {
+  const env = { ...process.env, ...options.env }
+  if (command === 'npm') {
+    env.npm_config_cache = npmCacheDirectory
+  }
+
   try {
     return execFileSync(command, args, {
-      cwd: process.cwd(),
+      cwd: options.cwd || process.cwd(),
+      env,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
     }).trim()
@@ -21,15 +31,15 @@ const runCommand = (command, args) => {
   }
 }
 
-const getAllJsFiles = (directory) =>
+const getAllFilesWithExtension = (directory, extension) =>
   fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
     const entryPath = path.join(directory, entry.name)
 
     if (entry.isDirectory()) {
-      return getAllJsFiles(entryPath)
+      return getAllFilesWithExtension(entryPath, extension)
     }
 
-    return entryPath.endsWith('.js') ? [entryPath] : []
+    return entryPath.endsWith(extension) ? [entryPath] : []
   })
 
 describe('build outputs', () => {
@@ -39,34 +49,46 @@ describe('build outputs', () => {
     runCommand('yarn', ['build'])
   })
 
-  it('produces loadable CJS and ESM bundles', async () => {
-    const cjsEntry = path.join(process.cwd(), 'lib', 'index.js')
-    const esmEntry = path.join(process.cwd(), 'esm', 'index.js')
+  it('produces loadable CJS and ESM bundles', () => {
+    const cjsEntry = path.join(process.cwd(), 'dist', 'index.cjs')
+    const esmEntry = path.join(process.cwd(), 'dist', 'index.mjs')
+    const destTypesEntry = path.join(process.cwd(), 'dist', 'index.d.ts')
 
     expect(fs.existsSync(cjsEntry)).toBe(true)
     expect(fs.existsSync(esmEntry)).toBe(true)
+    expect(fs.existsSync(destTypesEntry)).toBe(true)
 
     expect(() => require(cjsEntry)).not.toThrow()
 
-    await expect(import(pathToFileURL(esmEntry).href)).resolves.toBeDefined()
+    const esmEntryUrl = pathToFileURL(esmEntry).href
+    const esmOutput = runCommand('node', [
+      '--input-type=module',
+      '-e',
+      `import('${esmEntryUrl}').then((m)=>console.log(typeof m.convertToHTML))`,
+    ])
+    expect(esmOutput).toBe('function')
   })
 
-  it('exposes named exports for node ESM, node CJS, and tsx runtime', () => {
+  it('exposes named exports for node ESM', () => {
     const esmOutput = runCommand('node', [
       '--input-type=module',
       '-e',
       "import { convertToHTML } from '@20minutes/draft-convert'; console.log(typeof convertToHTML)",
     ])
     expect(esmOutput).toBe('function')
+  })
 
+  it('exposes named exports for node CJS', () => {
     const cjsOutput = runCommand('node', [
       '-e',
-      "const m=require('@20minutes/draft-convert'); console.log(typeof m.convertToHTML)",
+      "const { convertToHTML } = require('@20minutes/draft-convert'); console.log(typeof convertToHTML)",
     ])
     expect(cjsOutput).toBe('function')
+  })
 
-    const tsxOutput = runCommand('yarn', [
-      '-s',
+  it('exposes named exports for tsx runtime', () => {
+    const tsxOutput = runCommand('node', [
+      '--import',
       'tsx',
       '-e',
       "import { convertToHTML } from '@20minutes/draft-convert'; console.log(typeof convertToHTML)",
@@ -74,11 +96,11 @@ describe('build outputs', () => {
     expect(tsxOutput).toBe('function')
   })
 
-  it('adds .js extension to every relative ESM import/export specifier', () => {
-    const esmDirectory = path.join(process.cwd(), 'esm')
-    const jsFiles = getAllJsFiles(esmDirectory)
+  it('adds .mjs extension to every relative ESM import/export specifier', () => {
+    const distDirectory = path.join(process.cwd(), 'dist')
+    const mjsFiles = getAllFilesWithExtension(distDirectory, '.mjs')
 
-    for (const filePath of jsFiles) {
+    for (const filePath of mjsFiles) {
       const source = fs.readFileSync(filePath, 'utf8')
       const matches = source.matchAll(/(?:\bfrom\s+|\bimport\s*\()\s*['"]([^'"]+)['"]/g)
 
@@ -91,9 +113,56 @@ describe('build outputs', () => {
 
         const bareSpecifier = specifier.split(/[?#]/, 1)[0]
 
-        if (path.extname(bareSpecifier) !== '.js') {
-          throw new Error(`Missing .js extension in ${filePath} for specifier "${specifier}"`)
+        if (path.extname(bareSpecifier) !== '.mjs') {
+          throw new Error(`Missing .mjs extension in ${filePath} for specifier "${specifier}"`)
         }
+      }
+    }
+  })
+
+  it('works from npm pack tarball in a minimal ESM consumer', () => {
+    const rootDirectory = process.cwd()
+    const packOutput = runCommand('npm', ['pack', '--json'], {
+      cwd: rootDirectory,
+    })
+    const [{ filename }] = JSON.parse(packOutput)
+    const tarballPath = path.join(rootDirectory, filename)
+    const consumerDirectory = fs.mkdtempSync(
+      path.join(rootDirectory, `.tmp-consumer-${os.userInfo().username}-`)
+    )
+    const nodeModulesDirectory = path.join(consumerDirectory, 'node_modules')
+    const packageDirectory = path.join(nodeModulesDirectory, '@20minutes', 'draft-convert')
+
+    try {
+      fs.writeFileSync(
+        path.join(consumerDirectory, 'package.json'),
+        `${JSON.stringify({ name: 'draft-convert-consumer', private: true }, null, 2)}\n`,
+        'utf8'
+      )
+
+      fs.mkdirSync(path.dirname(packageDirectory), { recursive: true })
+      runCommand('tar', ['-xzf', tarballPath, '-C', consumerDirectory])
+      fs.renameSync(path.join(consumerDirectory, 'package'), packageDirectory)
+
+      const esmOutput = runCommand(
+        'node',
+        [
+          '--input-type=module',
+          '-e',
+          "import { convertToHTML } from '@20minutes/draft-convert'; console.log(typeof convertToHTML)",
+        ],
+        {
+          cwd: consumerDirectory,
+        }
+      )
+
+      expect(esmOutput).toBe('function')
+    } finally {
+      if (fs.existsSync(tarballPath)) {
+        fs.rmSync(tarballPath)
+      }
+      if (fs.existsSync(consumerDirectory)) {
+        fs.rmSync(consumerDirectory, { recursive: true, force: true })
       }
     }
   })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,114 +1,121 @@
 // Based on: https://github.com/HubSpot/draft-convert/issues/107#issuecomment-488581709 by <https://github.com/sbusch>
 // Grabbed from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/draft-convert/index.d.ts
 
-declare module "@20minutes/draft-convert" {
-    import {
-        ContentState,
-        DraftBlockType,
-        DraftEntityMutability,
-        DraftInlineStyleType,
-        Entity,
-        RawDraftContentBlock,
-        RawDraftEntity,
-    } from "draft-js";
-    import { ReactNode } from "react";
+import {
+  ContentState,
+  DraftBlockType,
+  DraftEntityMutability,
+  DraftInlineStyleType,
+  Entity,
+  RawDraftContentBlock,
+  RawDraftEntity,
+} from 'draft-js'
+import { ReactNode } from 'react'
 
-    type RawDraftContentBlockWithCustomType<T> = Omit<RawDraftContentBlock, "type"> & {
-        type: T;
-    };
-
-    type ExtendedHTMLElement<T> = (HTMLElement | HTMLLinkElement) & T;
-
-    interface IConvertToHTMLConfig<
-        S = DraftInlineStyleType,
-        B extends DraftBlockType = DraftBlockType,
-        E extends RawDraftEntity = RawDraftEntity,
-    > {
-        // Inline styles:
-        // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-        styleToHTML?: ((style: S) => Tag | void) | undefined;
-
-        // Block styles:
-        blockToHTML?: ((block: RawDraftContentBlockWithCustomType<B>) => Tag) | undefined;
-
-        // Entity styling:
-        entityToHTML?: ((entity: E, originalText: string) => Tag) | undefined;
-
-        // HTML validation:
-        validateHTML?: ((html: string) => boolean) | undefined;
-    }
-
-    type EntityKey = string;
-
-    interface IConvertFromHTMLConfig<
-        S extends {
-            [name: string]: unknown;
-        } = DOMStringMap,
-        B extends DraftBlockType = DraftBlockType,
-        E extends RawDraftEntity = RawDraftEntity,
-    > {
-        // Inline styles:
-        htmlToStyle?:
-            | ((nodeName: string, node: ExtendedHTMLElement<S>, currentStyle: Set<string>) => Set<string>)
-            | undefined;
-
-        // Block styles:
-        htmlToBlock?:
-            | ((
-                nodeName: string,
-                node: ExtendedHTMLElement<S>,
-            ) => B | { type: B; data: object } | false | undefined)
-            | undefined;
-
-        // Html entities
-        htmlToEntity?:
-            | ((
-                nodeName: string,
-                node: ExtendedHTMLElement<S>,
-                createEntity: (type: E["type"], mutability: DraftEntityMutability, data: E["data"]) => EntityKey,
-                getEntity: (key: EntityKey) => Entity,
-                mergeEntityData: (key: string, data: object) => void,
-                replaceEntityData: (key: string, data: object) => void,
-            ) => EntityKey | undefined)
-            | undefined;
-
-        // Text entities
-        textToEntity?:
-            | ((
-                text: string,
-                createEntity: (type: E["type"], mutability: DraftEntityMutability, data: E["data"]) => EntityKey,
-                getEntity: (key: EntityKey) => Entity,
-                mergeEntityData: (key: string, data: object) => void,
-                replaceEntityData: (key: string, data: object) => void,
-            ) => Array<{
-                entity: EntityKey;
-                offset: number;
-                length: number;
-                result?: string | undefined;
-            }>)
-            | undefined;
-    }
-
-    type ContentStateConverter = (contentState: ContentState) => string;
-    type HTMLConverter = (html: string) => ContentState;
-
-    type Tag = ReactNode | { start: string; end: string; empty?: string | undefined } | {
-        element: ReactNode;
-        empty?: ReactNode | undefined;
-    };
-
-    export function convertToHTML<
-        S = DraftInlineStyleType,
-        B extends DraftBlockType = DraftBlockType,
-        E extends RawDraftEntity = RawDraftEntity,
-    >(config: IConvertToHTMLConfig<S, B, E>): ContentStateConverter;
-    export function convertToHTML(contentState: ContentState): string;
-    export function convertFromHTML<
-        S extends {
-            [name: string]: unknown;
-        } = DOMStringMap,
-        B extends DraftBlockType = DraftBlockType,
-        E extends RawDraftEntity = RawDraftEntity,
-    >(config: IConvertFromHTMLConfig<S, B, E>): HTMLConverter;
-    export function convertFromHTML(html: string): ContentState;
+export type RawDraftContentBlockWithCustomType<T> = Omit<
+  RawDraftContentBlock,
+  'type'
+> & {
+  type: T
 }
+
+export type ExtendedHTMLElement<T> = (HTMLElement | HTMLLinkElement) & T
+
+export type EntityKey = string
+
+export type ContentStateConverter = (contentState: ContentState) => string
+export type HTMLConverter = (html: string) => ContentState
+
+export type Tag =
+  | ReactNode
+  | { start: string; end: string; empty?: string | undefined }
+  | {
+      element: ReactNode
+      empty?: ReactNode | undefined
+    }
+
+export interface IConvertToHTMLConfig<
+  S = DraftInlineStyleType,
+  B extends DraftBlockType = DraftBlockType,
+  E extends RawDraftEntity = RawDraftEntity,
+> {
+  // Inline styles:
+  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+  styleToHTML?: ((style: S) => Tag | null | undefined | void) | undefined
+
+  // Block styles:
+  blockToHTML?: ((block: RawDraftContentBlockWithCustomType<B>) => Tag | null | undefined) | undefined
+
+  // Entity styling:
+  entityToHTML?: ((entity: E, originalText: string) => Tag | null | undefined) | undefined
+
+  // HTML validation:
+  validateHTML?: ((html: string) => boolean) | undefined
+}
+
+export interface IConvertFromHTMLConfig<
+  S extends {
+    [name: string]: unknown
+  } = DOMStringMap,
+  B extends DraftBlockType = DraftBlockType,
+  E extends RawDraftEntity = RawDraftEntity,
+> {
+  // Inline styles:
+  htmlToStyle?:
+    | ((nodeName: string, node: ExtendedHTMLElement<S>, currentStyle: Set<string>) => Set<string>)
+    | undefined
+
+  // Block styles:
+  htmlToBlock?:
+    | ((
+        nodeName: string,
+        node: ExtendedHTMLElement<S>
+      ) => B | { type: B; data: object } | false | undefined)
+    | undefined
+
+  // Html entities
+  htmlToEntity?:
+    | ((
+        nodeName: string,
+        node: ExtendedHTMLElement<S>,
+        createEntity: (type: E['type'], mutability: DraftEntityMutability, data: E['data']) => EntityKey,
+        getEntity: (key: EntityKey) => Entity,
+        mergeEntityData: (key: string, data: object) => void,
+        replaceEntityData: (key: string, data: object) => void
+      ) => EntityKey | undefined)
+    | undefined
+
+  // Text entities
+  textToEntity?:
+    | ((
+        text: string,
+        createEntity: (type: E['type'], mutability: DraftEntityMutability, data: E['data']) => EntityKey,
+        getEntity: (key: EntityKey) => Entity,
+        mergeEntityData: (key: string, data: object) => void,
+        replaceEntityData: (key: string, data: object) => void
+      ) => Array<{
+        entity: EntityKey
+        offset: number
+        length: number
+        result?: string | undefined
+      }>)
+    | undefined
+}
+
+export function convertToHTML<
+  S = DraftInlineStyleType,
+  B extends DraftBlockType = DraftBlockType,
+  E extends RawDraftEntity = RawDraftEntity,
+>(config: IConvertToHTMLConfig<S, B, E>): ContentStateConverter
+export function convertToHTML(contentState: ContentState): string
+
+export function convertFromHTML<
+  S extends {
+    [name: string]: unknown
+  } = DOMStringMap,
+  B extends DraftBlockType = DraftBlockType,
+  E extends RawDraftEntity = RawDraftEntity,
+>(config: IConvertFromHTMLConfig<S, B, E>): HTMLConverter
+export function convertFromHTML(html: string): ContentState
+
+export function parseHTML(html: string): HTMLBodyElement

--- a/yarn.lock
+++ b/yarn.lock
@@ -576,11 +576,6 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
-"@isaacs/cliui@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-9.0.0.tgz#4d0a3f127058043bf2e7ee169eaf30ed901302f3"
-  integrity sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==
-
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -1662,9 +1657,9 @@ available-typed-arrays@^1.0.7:
     possible-typed-array-names "^1.0.0"
 
 b4a@^1.6.4:
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.7.4.tgz#0fdcb68cbc0224d267e3d0519c66419efc3416e2"
-  integrity sha512-u20zJLDaSWpxaZ+zaAkEIB2dZZ1o+DF4T/MRbmsvGp9nletHOyiai19OzX1fF8xUBYsO1bPXxODvcd0978pnug==
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.7.5.tgz#573e93bf2664de8779069ef736615c1c63ec1b74"
+  integrity sha512-iEsKNwDh1wiWTps1/hdkNdmBgDlDVZP5U57ZVOlt+dNFqpc/lpPouCIxZw+DYBgc4P9NDfIZMPNR4CHNhzwLIA==
 
 babel-jest@30.2.0:
   version "30.2.0"
@@ -1732,11 +1727,9 @@ balanced-match@^1.0.0:
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 balanced-match@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.2.tgz#241591ea634702bef9c482696f2469406e16d233"
-  integrity sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==
-  dependencies:
-    jackspeak "^4.2.3"
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.3.tgz#6337a2f23e0604a30481423432f99eac603599f9"
+  integrity sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==
 
 bare-events@^2.7.0:
   version "2.8.2"
@@ -2861,11 +2854,11 @@ glob@^10.3.10:
     path-scurry "^1.11.1"
 
 glob@^13.0.3:
-  version "13.0.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-13.0.3.tgz#e5c39b3e0eb8a2e2bc35e3b28e78fd0839ff9e68"
-  integrity sha512-/g3B0mC+4x724v1TgtBlBtt2hPi/EWptsIAmXUx9Z2rvBYleQcsrmaOzd5LyL50jf/Soi83ZDJmw2+XqvH/EeA==
+  version "13.0.5"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-13.0.5.tgz#a48f760c6312b1a19d2950fcb577384221c4ec00"
+  integrity sha512-BzXxZg24Ibra1pbQ/zE7Kys4Ua1ks7Bn6pKLkVPZ9FZe4JQS6/Q7ef3LG1H+k7lUf5l4T3PLSyYyYJVYUvfgTw==
   dependencies:
-    minimatch "^10.2.0"
+    minimatch "^10.2.1"
     minipass "^7.1.2"
     path-scurry "^2.0.0"
 
@@ -3396,13 +3389,6 @@ jackspeak@^3.1.2:
     "@isaacs/cliui" "^8.0.2"
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
-
-jackspeak@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-4.2.3.tgz#27ef80f33b93412037c3bea4f8eddf80e1931483"
-  integrity sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==
-  dependencies:
-    "@isaacs/cliui" "^9.0.0"
 
 jest-changed-files@30.2.0:
   version "30.2.0"
@@ -3999,10 +3985,10 @@ mimic-response@^4.0.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-4.0.0.tgz#35468b19e7c75d10f5165ea25e75a5ceea7cf70f"
   integrity sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==
 
-minimatch@^10.2.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.0.tgz#e710473e66e3e1aaf376d0aa82438375cac86e9e"
-  integrity sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w==
+minimatch@^10.2.1:
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.1.tgz#9d82835834cdc85d5084dd055e9a4685fa56e5f0"
+  integrity sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==
   dependencies:
     brace-expansion "^5.0.2"
 
@@ -4044,6 +4030,16 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+node-exports-info@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/node-exports-info/-/node-exports-info-1.6.0.tgz#1aedafb01a966059c9a5e791a94a94d93f5c2a13"
+  integrity sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==
+  dependencies:
+    array.prototype.flatmap "^1.3.3"
+    es-errors "^1.3.0"
+    object.entries "^1.1.9"
+    semver "^6.3.1"
 
 node-fetch@^2.7.0:
   version "2.7.0"
@@ -4482,11 +4478,14 @@ resolve@^1.22.4:
     supports-preserve-symlinks-flag "^1.0.0"
 
 resolve@^2.0.0-next.5:
-  version "2.0.0-next.5"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-2.0.0-next.5.tgz#6b0ec3107e671e52b68cd068ef327173b90dc03c"
-  integrity sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==
+  version "2.0.0-next.6"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-2.0.0-next.6.tgz#b3961812be69ace7b3bc35d5bf259434681294af"
+  integrity sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==
   dependencies:
-    is-core-module "^2.13.0"
+    es-errors "^1.3.0"
+    is-core-module "^2.16.1"
+    node-exports-info "^1.6.0"
+    object-keys "^1.1.1"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 


### PR DESCRIPTION
Reworked `types/index.d.ts` to use direct module exports (no ambient `declare module`) and widened `IConvertToHTMLConfig` callback return types to include `null`/`undefined`/`void`, preventing ambiguous overload resolution in TypeScript consumers

Also fix import from immutable & draft-js